### PR TITLE
Remove inline style of .dawandaWidgetContent

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -172,7 +172,7 @@ DaWanda.Widget.prototype = {
       (eval(this.options.autoSlide) ? '    <div class="auto-slider" rel="' + this.options.sourceId +'"></div>' : '') +
       '   <table border="0" cellspacing="0" cellpadding="0" width="100%">' +
       '     <tr>' +
-      '       <td style="padding: 15px 0px 0px 0px" class="dawandaWidgetContent" colspan="2">' +
+      '       <td class="dawandaWidgetContent" colspan="2">' +
       '         <div id="dawandaWidgetHeadline" style="' + (showNormalVersion ? '' : 'height: 20px') + '">'
 
       if(!eval(this.options.hideLogo))
@@ -421,6 +421,10 @@ DaWanda.Widget.prototype = {
                                                                                                                                                                                             \
       %{containerId} #dawandaWidgetContainer .productInformation a {                                                                                                                        \
         line-height: 15px;                                                                                                                                                                  \
+      }                                                                                                                                                                                     \
+                                                                                                                                                                                            \
+      %{containerId} .dawandaWidgetContent {                                                                                                                                                \
+        padding: 15px 0px 0px 0px;                                                                                                                                                          \
       }                                                                                                                                                                                     \
       "
 

--- a/widget.js
+++ b/widget.js
@@ -52,13 +52,18 @@ DaWanda.Widget.prototype = {
   },
 
   getInsertPoint: function() {
-    var result = null
-    var self = this
-    jQuery("script").each(function() {
-      if((this.text.indexOf("new DaWanda.Widget({") > -1) && (this.text.indexOf(self.options.sourceId.toString()) > -1))
-        result = this
-    })
-    return result
+    if this.options.containerElement != null {
+      return jQuery(this.options.containerElement)
+
+    } else {
+      var result = null
+      var self = this
+      jQuery("script").each(function() {
+        if((this.text.indexOf("new DaWanda.Widget({") > -1) && (this.text.indexOf(self.options.sourceId.toString()) > -1))
+          result = this
+      })
+      return result
+    }
   },
 
   imageWidth: function() {
@@ -214,7 +219,11 @@ DaWanda.Widget.prototype = {
       '</div>'
 
       _this.containerId = _this.getUniqueContainerId("dawandaWidgetOuterContainer")
-      jQuery(this.getInsertPoint()).after(jQuery("<div></div>").attr("id", _this.containerId).append(result))
+      if this.options.containerElement != null {
+        jQuery(this.getInsertPoint()).attr("id", _this.containerId).append(result))
+      } else {
+        jQuery(this.getInsertPoint()).after(jQuery("<div></div>").attr("id", _this.containerId).append(result))
+      }
       _this.renderCss()
 
       window.setTimeout(function() {


### PR DESCRIPTION
We are writing our own styles for the dawanda widget integration and disabling it was actually pretty simple with your code structure.  I just did a `DaWanda.Widget.prototype.renderCss = function() { return ""; };`.

However while trying to do our own styling all the inline styles were pretty annoying, the one in this pull request in particular.
