### PR TITLE
Allow widget to be inserted into custom container and make images responsive (based on container width)

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -24,7 +24,9 @@ DaWanda.Widget = function(options) {
     language: 'de',
     hideLogo: false,
     titleFontSize: 12,
-    uuid: 'old-installation'
+    uuid: 'old-installation',
+    containerElement: null,
+    responsiveImageWidth: false
   }, options)
 
   this.api = new DaWanda.API("c140e138d812449959a6d5a7b0d8258197edeb58", this.options.language)
@@ -52,7 +54,7 @@ DaWanda.Widget.prototype = {
   },
 
   getInsertPoint: function() {
-    if this.options.containerElement != null {
+    if (this.options.containerElement != null) {
       return jQuery(this.options.containerElement)
 
     } else {
@@ -107,7 +109,11 @@ DaWanda.Widget.prototype = {
     var image = new Image()
     var self = this
     image.onload = function() {
-      self.options.imageWidth = image.width
+      if (self.options.responsiveImageWidth == true) {
+        self.options.imageWidth = (self.getInsertPoint().width() - 2) / 2 - 2*10
+      } else {
+        self.options.imageWidth = image.width
+      }
       self.renderProducts()
     }
     image.src = this.getImageUrl(this.products[0])
@@ -177,7 +183,7 @@ DaWanda.Widget.prototype = {
       (eval(this.options.autoSlide) ? '    <div class="auto-slider" rel="' + this.options.sourceId +'"></div>' : '') +
       '   <table border="0" cellspacing="0" cellpadding="0" width="100%">' +
       '     <tr>' +
-      '       <td style="padding: 15px 0px 0px 0px" class="dawandaWidgetContent" colspan="2">' +
+      '       <td class="dawandaWidgetContent" colspan="2">' +
       '         <div id="dawandaWidgetHeadline" style="' + (showNormalVersion ? '' : 'height: 20px') + '">'
 
       if(!eval(this.options.hideLogo))
@@ -219,8 +225,8 @@ DaWanda.Widget.prototype = {
       '</div>'
 
       _this.containerId = _this.getUniqueContainerId("dawandaWidgetOuterContainer")
-      if this.options.containerElement != null {
-        jQuery(this.getInsertPoint()).attr("id", _this.containerId).append(result))
+      if (this.options.containerElement != null) {
+        jQuery(this.getInsertPoint()).attr("id", _this.containerId).append(result)
       } else {
         jQuery(this.getInsertPoint()).after(jQuery("<div></div>").attr("id", _this.containerId).append(result))
       }
@@ -293,36 +299,36 @@ DaWanda.Widget.prototype = {
       %{containerId} var, %{containerId} b, %{containerId} u, %{containerId} i, %{containerId} center, %{containerId} dl, %{containerId} dt, %{containerId} dd, %{containerId} ol,          \
       %{containerId} ul, %{containerId} li, %{containerId} fieldset, %{containerId} form, %{containerId} label, %{containerId} legend, %{containerId} table, %{containerId} caption,        \
       %{containerId} tbody, %{containerId} tfoot, %{containerId} thead, %{containerId} tr, %{containerId} th, %{containerId} td {                                                           \
-      	margin: 0;                                                                                                                                                                          \
-      	padding: 0;                                                                                                                                                                         \
-      	border: 0;                                                                                                                                                                          \
-      	outline: 0;                                                                                                                                                                         \
-      	font-size: 100%;                                                                                                                                                                    \
-      	vertical-align: baseline;                                                                                                                                                           \
-      	background: transparent;                                                                                                                                                            \
-      	line-height: 1;                                                                                                                                                                     \
+        margin: 0;                                                                                                                                                                          \
+        padding: 0;                                                                                                                                                                         \
+        border: 0;                                                                                                                                                                          \
+        outline: 0;                                                                                                                                                                         \
+        font-size: 100%;                                                                                                                                                                    \
+        vertical-align: baseline;                                                                                                                                                           \
+        background: transparent;                                                                                                                                                            \
+        line-height: 1;                                                                                                                                                                     \
       }                                                                                                                                                                                     \
       %{containerId} ol, %{containerId} ul {                                                                                                                                                \
-      	list-style: none;                                                                                                                                                                   \
+        list-style: none;                                                                                                                                                                   \
       }                                                                                                                                                                                     \
       %{containerId} blockquote, %{containerId} q {                                                                                                                                         \
-      	quotes: none;                                                                                                                                                                       \
+        quotes: none;                                                                                                                                                                       \
       }                                                                                                                                                                                     \
                                                                                                                                                                                             \
       %{containerId} :focus {                                                                                                                                                               \
-      	outline: 0;                                                                                                                                                                         \
+        outline: 0;                                                                                                                                                                         \
       }                                                                                                                                                                                     \
                                                                                                                                                                                             \
       %{containerId} ins {                                                                                                                                                                  \
-      	text-decoration: none;                                                                                                                                                              \
+        text-decoration: none;                                                                                                                                                              \
       }                                                                                                                                                                                     \
       %{containerId} del {                                                                                                                                                                  \
-      	text-decoration: line-through;                                                                                                                                                      \
+        text-decoration: line-through;                                                                                                                                                      \
       }                                                                                                                                                                                     \
                                                                                                                                                                                             \
       %{containerId} table {                                                                                                                                                                \
-      	border-collapse: collapse;                                                                                                                                                          \
-      	border-spacing: 0;                                                                                                                                                                  \
+        border-collapse: collapse;                                                                                                                                                          \
+        border-spacing: 0;                                                                                                                                                                  \
       }                                                                                                                                                                                     \
     "
 
@@ -430,6 +436,10 @@ DaWanda.Widget.prototype = {
                                                                                                                                                                                             \
       %{containerId} #dawandaWidgetContainer .productInformation a {                                                                                                                        \
         line-height: 15px;                                                                                                                                                                  \
+      }                                                                                                                                                                                     \
+                                                                                                                                                                                            \
+      %{containerId} .dawandaWidgetContent {                                                                                                                                                \
+        padding: 15px 0px 0px 0px;                                                                                                                                                          \
       }                                                                                                                                                                                     \
       "
 

--- a/widget.js
+++ b/widget.js
@@ -52,13 +52,18 @@ DaWanda.Widget.prototype = {
   },
 
   getInsertPoint: function() {
-    var result = null
-    var self = this
-    jQuery("script").each(function() {
-      if((this.text.indexOf("new DaWanda.Widget({") > -1) && (this.text.indexOf(self.options.sourceId.toString()) > -1))
-        result = this
-    })
-    return result
+    if this.options.containerElement != null {
+      return jQuery(this.options.containerElement)
+
+    } else {
+      var result = null
+      var self = this
+      jQuery("script").each(function() {
+        if((this.text.indexOf("new DaWanda.Widget({") > -1) && (this.text.indexOf(self.options.sourceId.toString()) > -1))
+          result = this
+      })
+      return result
+    }
   },
 
   imageWidth: function() {
@@ -214,7 +219,11 @@ DaWanda.Widget.prototype = {
       '</div>'
 
       _this.containerId = _this.getUniqueContainerId("dawandaWidgetOuterContainer")
-      jQuery(this.getInsertPoint()).after(jQuery("<div></div>").attr("id", _this.containerId).append(result))
+      if this.options.containerElement != null {
+        jQuery(this.getInsertPoint()).attr("id", _this.containerId).append(result))
+      } else {
+        jQuery(this.getInsertPoint()).after(jQuery("<div></div>").attr("id", _this.containerId).append(result))
+      }
       _this.renderCss()
 
       window.setTimeout(function() {


### PR DESCRIPTION
Since all of our javascript is loaded in one file at the end of the `<body>` for performance reasons, we needed a way to insert the widget from within that file.  For that we included the dawanda scripts and put an empty `#dawanda-widget` div at the position in the HTML where we want the widget to appear.

Then we initialize the widget with this code (coffeescript):

```
dawandaWidget = new DaWanda.Widget
  containerElement: "#dawanda-widget"
```

Because none of the default image size options fit into our design, I also created an option to make these widths responsive based on the width of the container.
