### PR TITLE
simpleSlide compatibility with current jQuery

### DIFF
--- a/jquery.simpleSlide.js
+++ b/jquery.simpleSlide.js
@@ -338,7 +338,7 @@ function ssInit(){
     };
             
     /* Actuates upon the clicking of a left- or right-button classed element */
-    $('.left-button, .right-button, .jump-to').live('click', function() {
+    $('#dawandaWidgetOuterContainer').on('click', '.left-button, .right-button, .jump-to', function() {
       
       var rel = $(this).attr('rel');
       

--- a/jquery.simpleSlide.js
+++ b/jquery.simpleSlide.js
@@ -212,7 +212,7 @@ function ssInit(){
   
       $(this).find('#ssLoading').remove();
             
-      if($.ss_options.swipe = 'true' && !$.browser.msie){
+      if($.ss_options.swipe = 'true'){
         simpleSwipe(this);
       };
           

--- a/widget.js
+++ b/widget.js
@@ -172,7 +172,7 @@ DaWanda.Widget.prototype = {
       (eval(this.options.autoSlide) ? '    <div class="auto-slider" rel="' + this.options.sourceId +'"></div>' : '') +
       '   <table border="0" cellspacing="0" cellpadding="0" width="100%">' +
       '     <tr>' +
-      '       <td style="padding: 15px 0px 0px 0px" class="dawandaWidgetContent" colspan="2">' +
+      '       <td class="dawandaWidgetContent" colspan="2">' +
       '         <div id="dawandaWidgetHeadline" style="' + (showNormalVersion ? '' : 'height: 20px') + '">'
 
       if(!eval(this.options.hideLogo))
@@ -421,6 +421,10 @@ DaWanda.Widget.prototype = {
                                                                                                                                                                                             \
       %{containerId} #dawandaWidgetContainer .productInformation a {                                                                                                                        \
         line-height: 15px;                                                                                                                                                                  \
+      }                                                                                                                                                                                     \
+                                                                                                                                                                                            \
+      %{containerId} .dawandaWidgetContent {                                                                                                                                                \
+        padding: 15px 0px 0px 0px;                                                                                                                                                          \
       }                                                                                                                                                                                     \
       "
 

--- a/widget.js
+++ b/widget.js
@@ -52,13 +52,18 @@ DaWanda.Widget.prototype = {
   },
 
   getInsertPoint: function() {
-    var result = null
-    var self = this
-    jQuery("script").each(function() {
-      if((this.text.indexOf("new DaWanda.Widget({") > -1) && (this.text.indexOf(self.options.sourceId.toString()) > -1))
-        result = this
-    })
-    return result
+    if this.options.containerElement != null {
+      return jQuery(this.options.containerElement)
+
+    } else {
+      var result = null
+      var self = this
+      jQuery("script").each(function() {
+        if((this.text.indexOf("new DaWanda.Widget({") > -1) && (this.text.indexOf(self.options.sourceId.toString()) > -1))
+          result = this
+      })
+      return result
+    }
   },
 
   imageWidth: function() {
@@ -214,7 +219,11 @@ DaWanda.Widget.prototype = {
       '</div>'
 
       _this.containerId = _this.getUniqueContainerId("dawandaWidgetOuterContainer")
-      jQuery(this.getInsertPoint()).after(jQuery("<div></div>").attr("id", _this.containerId).append(result))
+      if this.options.containerElement != null {
+        jQuery(this.getInsertPoint()).attr("id", _this.containerId).append(result))
+      } else {
+        jQuery(this.getInsertPoint()).after(jQuery("<div></div>").attr("id", _this.containerId).append(result))
+      }
       _this.renderCss()
 
       window.setTimeout(function() {


### PR DESCRIPTION
This makes simpleSlide compatible with current jQuery versions.  It definitely requires at least version 1.7, so you might think about cutting a new release.

This pull request is actually only about commits c0e259e and 7534274.   Either you get these changes manually or I can try to create a new clean PR.
